### PR TITLE
MAINT Fix API Calling functions

### DIFF
--- a/files/api/activity.rb
+++ b/files/api/activity.rb
@@ -27,13 +27,13 @@ module PeEventForwarding
         response       = pe_client.pe_get_request('activity-api/v2/events', params)
         response_body  = JSON.parse(response.body)
         total_count    = response_body['pagination']['total']
-        response_items << response_body['items']
+        response_body['commits']&.map { |commit| response_items << commit }
 
-        break if response_items.count != api_window_size
+        break if response_body['commits'].nil? || response_body['commits'].count != api_window_size
         params[:offset] += api_window_size
       end
       raise 'Events API request failed' unless response.code == '200'
-      { 'pagination' => { 'total' => total_count }, 'items' => response_items }
+      { 'pagination' => { 'total' => total_count }, 'commits' => response_items }
     end
 
     def current_event_count(service_name)

--- a/files/api/orchestrator.rb
+++ b/files/api/orchestrator.rb
@@ -25,9 +25,9 @@ module PeEventForwarding
         response       = pe_client.pe_get_request('orchestrator/v1/jobs', params)
         response_body  = JSON.parse(response.body)
         total_count    = response_body['pagination']['total']
-        response_items << response_body['items']
+        response_body['items']&.map { |item| response_items << item }
 
-        break if response_items.count != api_window_size
+        break if response_body['items'].nil? || response_body['items'].count != api_window_size
         params[:offset] += api_window_size
       end
       raise 'Orchestrator API request failed' unless response.code == '200'


### PR DESCRIPTION
The functions get_events and get_jobs in activity.rb and
orchestrator.rb respectively, now concatenate the items array correctly
and the loop conditions for getting items from the API call now
check the correct array count.

The activity.rb specifically, now generates the correct final hash
with the key `commits`.