### PR TITLE
MAINT Recreate Event Hashes

### DIFF
--- a/files/api/activity.rb
+++ b/files/api/activity.rb
@@ -33,7 +33,7 @@ module PeEventForwarding
         params[:offset] += api_page_size
       end
       raise 'Events API request failed' unless response.code == '200'
-      { 'pagination' => { 'total' => total_count }, 'commits' => response_items }
+      { 'api_total_count' => total_count, 'events' => response_items }
     end
 
     def current_event_count(service_name)

--- a/files/api/orchestrator.rb
+++ b/files/api/orchestrator.rb
@@ -31,7 +31,7 @@ module PeEventForwarding
         params[:offset] += api_page_size
       end
       raise 'Orchestrator API request failed' unless response.code == '200'
-      { 'pagination' => { 'total' => total_count }, 'items' => response_items }
+      { 'api_total_count' => total_count, 'events' => response_items }
     end
 
     def run_facts_task(nodes)

--- a/files/util/index.rb
+++ b/files/util/index.rb
@@ -45,7 +45,7 @@ module PeEventForwarding
       data = counts(refresh: true)
       service.each do |key, value|
         next if value.nil?
-        data[key] = value.is_a?(Integer) ? value : value['pagination']['total']
+        data[key] = value.is_a?(Integer) ? value : value['api_total_count']
       end
       File.write(filepath, data.to_yaml)
       @counts = data


### PR DESCRIPTION
For consistency, made the resulting hash of `get_events` and `get_jobs`
from orchestrator.rb and activity.rb (respectively) to have the same
keys.