### PR TITLE
(MAINT) Fix the forge deploy workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,26 +6,20 @@ on:
     - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
-  release:
-    env:
-      BLACKSMITH_FORGE_USERNAME: ${{ secrets.FORGE_USERNAME }}
-      BLACKSMITH_FORGE_PASSWORD: ${{ secrets.FORGE_PASSWORD }}
-    runs-on: ubuntu-latest
+  deploy-forge:
+    name: Deploy to Forge
+    runs-on: ubuntu-20.04
     steps:
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.5.3
-    - name: Update Rubygems
-      run: gem update --system 3.1.0
-    - name: Get latest tag
-      run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
-    - name: Clone repository
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ env.RELEASE_VERSION }}
-    - name: Release
-      run: | 
-        bundle install --with release
-        bundle exec rake module:build
-        bundle exec rake module:push
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          clean: true
+      - name: "PDK Build"
+        uses: docker://puppet/pdk:nightly
+        with:
+          args: 'build'
+      - name: "Push to Forge"
+        uses: docker://puppet/pdk:nightly
+        with:
+          args: 'release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force'


### PR DESCRIPTION
The forge now uses an API key and a PDK docker container to deploy
to the forge from Github actions workflows. This change updates the
workflows to comply with the new process.