### PR TITLE
(MAINT) GH security move from git to https

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,12 +12,10 @@ fixtures:
     puppet_conf: 'puppetlabs/puppet_conf'
     deploy_pe: 'jarretlavallee/deploy_pe'
     cron_core: 'puppetlabs/cron_core'
+    stdlib: 'puppetlabs/stdlib'
+    puppet_agent: 'puppetlabs/puppet_agent'
+    facts: 'puppetlabs/facts'
   repositories:
-    "stdlib":
-      "repo": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "translate":
-      "repo": "https://github.com/puppetlabs/puppetlabs-translate"
-    facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
-    puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'git://github.com/puppetlabs/provision.git'
-    litmus: 'git://github.com/puppetlabs/litmus.git'
+    translate: 'https://github.com/puppetlabs/puppetlabs-translate'
+    provision: 'https://github.com/puppetlabs/provision'
+    litmus: 'https://github.com/puppetlabs/litmus'


### PR DESCRIPTION
# Summary

Per recent changes to [GH security](https://github.blog/2021-09-01-improving-git-protocol-security-github/), updated repo source protocols in `.fixures.yaml`.

# Detailed Description

  * Updated `.fixtures.yaml` to move public repo sources from `git` to `https` protocol.