### PR TITLE
(PIE-1034) Ensure lockfile only deleted when appropriate

### DIFF
--- a/files/util/lockfile.rb
+++ b/files/util/lockfile.rb
@@ -31,9 +31,15 @@ module PeEventForwarding
       File.write(filepath, body.to_json)
     end
 
-    def remove_lockfile
+    def same_pid_as_lockfile?
+      info['pid'] == Process.pid
+    end
+
+    # The force argument will delete the lockfile even if it does not belong to the current process.
+    # This is useful if we have confirmed the process is no longer running.
+    def remove_lockfile(force: false)
       raise 'Cannot delete Lockfile. Does not exist.' unless lockfile_exists?
-      File.delete(filepath)
+      File.delete(filepath) if force || same_pid_as_lockfile?
     end
 
     def already_running?
@@ -46,7 +52,7 @@ module PeEventForwarding
       !info['program_name'].match(%r{#{command}}).nil?
     rescue
       # Remove lock if the process is no longer running.
-      remove_lockfile
+      remove_lockfile(force: true)
       false
     end
   end


### PR DESCRIPTION
The collect_api_events.rb script will check if another instance of the
script is running and exit if so. The problem arises when the exit is
caught so we can create the appropriate log messages and an ensure block
deletes the lockfile. In scenarios where the cron calls start to stack
on each other this ensure clause can delete lockfiles created by other
running instances of collect_api_events.rb.

To solve this we introduce a check before deleting the lockfile to
ensure that the current pid matches the pid in the lockfile. There is a
force parameter to override this check which is used by the
validate_command in the case that the pid referenced in the lockfile no
longer exists.