### PR TITLE
(PIE-1162) Update cron user

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,7 +115,7 @@ class pe_event_forwarding (
   cron { 'collect_pe_events':
     ensure   => $cron_ensure,
     command  => "${full_confdir}/collect_api_events.rb ${full_confdir} ${logfile_basepath}/pe_event_forwarding/pe_event_forwarding.log ${lockdir_basepath}/pe_event_forwarding/cache/state",
-    user     => 'root',
+    user     => $owner,
     minute   => $cron_minute,
     hour     => $cron_hour,
     weekday  => $cron_weekday,

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -41,12 +41,12 @@ describe 'Verify the minimum install' do
 
   describe 'configures cron' do
     it 'enables cron' do
-      result = puppetserver.run_shell('crontab -l', expect_failures: true).stdout
+      result = puppetserver.run_shell('crontab -u pe-puppet -l', expect_failures: true).stdout
       expect(result.include?('collect_api_events.rb')).to be true
     end
 
     it 'applies the correct schedule' do
-      result = puppetserver.run_shell('crontab -l', expect_failures: true).stdout
+      result = puppetserver.run_shell('crontab -u pe-puppet -l', expect_failures: true).stdout
       expect(result.include?('10 9 6 7 3')).to be true
     end
   end


### PR DESCRIPTION
# Summary

Changes to `init.pp` to default cron owner to the `$owner` variable.

# Detailed Description

  * Updated **L118** in `manifests/init.pp` from `root` -> `$owner`.
  * Updated **L49** and **L49** `spec/acceptance/class_spec.rb` to include the `pe-puppet` user in the `crontab` command.