### PR TITLE
(MAINT) Fix base_path function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding)
 
+### Fixed
+
+- Internal `base_path` function now removes any trailing slash (`/`) from user provided config directories. [#118](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/pull/118)
+
 [Current Diff](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v1.1.0..main)
 
 ## [v2.0.0](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/tree/v2.0.0) (2023-05-XX)

--- a/lib/puppet/functions/pe_event_forwarding/base_path.rb
+++ b/lib/puppet/functions/pe_event_forwarding/base_path.rb
@@ -8,13 +8,13 @@ Puppet::Functions.create_function(:'pe_event_forwarding::base_path') do
   # @example Calling the function
   #   pe_event_forwarding::base_path(default_path, desired_path)
   def base_path(str, path)
-    # No specific path is provided, going to use default path from logdir
+    # No specific path is provided, going to use default path from Puppet settings
     if path.nil?
       base = str.match(%r{^(.*?\/puppetlabs)\/})
       (!base.nil?) ? base[1] : str
     # A specfic path is provided
     else
-      path
+      path.chomp('/')
     end
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,9 +114,15 @@ class pe_event_forwarding (
     "${lockdir_basepath}/pe_event_forwarding/cache/state",
   ]
 
+  $cron_command = @("COMMAND"/L)
+    ${full_confdir}/collect_api_events.rb ${full_confdir} \
+    ${logfile_basepath}/pe_event_forwarding/pe_event_forwarding.log \
+    ${lockdir_basepath}/pe_event_forwarding/cache/state
+    |-COMMAND
+
   cron { 'collect_pe_events':
     ensure   => $cron_ensure,
-    command  => "${full_confdir}/collect_api_events.rb ${full_confdir} ${logfile_basepath}/pe_event_forwarding/pe_event_forwarding.log ${lockdir_basepath}/pe_event_forwarding/cache/state",
+    command  => $cron_command,
     user     => $owner,
     minute   => $cron_minute,
     hour     => $cron_hour,


### PR DESCRIPTION
# Summary

This maintenance PR addresses a bug in the internal `base_path` function where a path in the cron command is created with a double slash (`//`) when a user provided path ends in a slash.

# Detailed Description

  * Updated `CHANGELOG.md`
  * Fix lint error in `init.pp` by utilizing Heredoc
  * `lib/puppet/functions/pe_event_forwarding/base_path.rb`
    * Remove any trailing `/` from user provided base path.