### PR TITLE
(PIE-1300) Puppet 8 Compatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,17 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
 {
 	"name": "Puppet Development Kit (Community)",
 	"dockerFile": "Dockerfile",
 
-	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash"
+			}
+		}
 	},
 
-	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"puppet.puppet-vscode",
 		"rebornix.Ruby"
 	]
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pdk --version",
 }

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -2,120 +2,78 @@ name: "Integration Testing"
 
 on: [pull_request]
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   Integration:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        platform:
+        platforms:
           - centos-7
         pe_version:
-          - 2019.8.7
+          - 2021.7.3
 
     env:
-      BUILDEVENT_FILE: "../buildevents.txt"
-      CLOUD_CI: 'true'
-      DOCKER_OPTS:  --registry-mirror=https://mirror.gcr.io
+      PUPPET_GEM_VERSION: '~> 7.24'
 
     steps:
-      - run: |
-          echo 'platform=${{ matrix.platform }}' >> $BUILDEVENT_FILE
-          echo 'pe_version=${{ matrix.pe_version }}' >> $BUILDEVENT_FILE
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-          matrix-key: ${{ matrix.platform }}-${{ matrix.pe_version }}
+    - name: Checkout Source
+      uses: actions/checkout@v3
 
-      - name: "Honeycomb: start first step"
-        run: |
-          echo STEP_ID=${{ matrix.platform }}-${{ matrix.pe_version }}-1 >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-      - name: Checkout Source
-        uses: actions/checkout@v2
+    - name: Activate Ruby 2.7
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "2.7"
+        bundler-cache: true
 
-      - name: Activate Ruby 2.7
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "2.7"
-          bundler-cache: true
-
-      - name: Print bundle environment
-        run: |
-          echo ::group::bundler environment
-          buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-      - name: Create the fixtures directory
-        run: |
-          echo ::group::Create the fixtures directory
-          buildevents cmd $TRACE_ID $STEP_ID 'bundle exec rake spec_prep' -- bundle exec rake spec_prep
-          echo ::endgroup::
-      - name: "Honeycomb: Record Setup Environment time"
-        if: ${{ always() }}
-        run: |
-          buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
-          echo STEP_ID=${{ matrix.platform }}-${{ matrix.pe_version }}-2 >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-      - name: Provision test environment
-        run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run pe_event_forwarding::acceptance::provision_machines' -- bundle exec bolt --modulepath spec/fixtures/modules plan run pe_event_forwarding::acceptance::provision_machines using='provision_service' image='${{ matrix.platform }}'
+    - name: Print bundle environment
+      run: |
+        echo ::group::bundler environment
+        bundle env
+        echo ::endgroup::
+    - name: Create the fixtures directory
+      run: |
+        echo ::group::Create the fixtures directory
+        bundle exec rake spec_prep
+        echo ::endgroup::
+    - name: Provision test environment
+      run: |
+        bundle exec bolt --modulepath spec/fixtures/modules plan run pe_event_forwarding::acceptance::provision_machines using='provision_service' image='${{ matrix.platforms }}'
+        echo ::group::=== REQUEST ===
+        cat request.json || true
+        echo
+        echo ::endgroup::
+        echo ::group::=== INVENTORY ===
+        if [ -f 'spec/fixtures/litmus_inventory.yaml' ];
+        then
+          FILE='spec/fixtures/litmus_inventory.yaml'
+        elif [ -f 'inventory.yaml' ];
+        then
+          FILE='inventory.yaml'
+        fi
+        sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
+        echo ::endgroup::
+        echo INVENTORY_PATH=$FILE >> $GITHUB_ENV
+    - name: Install server
+      run: |
+        bundle exec bolt --modulepath spec/fixtures/modules plan run pe_event_forwarding::acceptance::pe_server version='${{ matrix.pe_version }}' -i ./$INVENTORY_PATH --stream
+    - name: Add localhost target to inventory
+      run: |
+        bundle exec rake 'acceptance:add_localhost_target'
+    - name: Install module
+      run: |
+        bundle exec rake 'litmus:install_module'
+    - name: Run acceptance tests
+      run: |
+        bundle exec rake acceptance:run_tests
+    - name: Remove test environment
+      if: ${{ always() }}
+      continue-on-error: true
+      run: |
+        if [[ -f inventory.yaml || -f spec/fixtures/litmus_inventory.yaml ]]; then
+          bundle exec rake 'litmus:tear_down'
           echo ::group::=== REQUEST ===
           cat request.json || true
           echo
           echo ::endgroup::
-          echo ::group::=== INVENTORY ===
-          if [ -f 'spec/fixtures/litmus_inventory.yaml' ]; then
-            FILE='spec/fixtures/litmus_inventory.yaml'
-          elif [ -f 'inventory.yaml' ]; then
-            FILE='inventory.yaml'
-          fi
-          sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
-          echo ::endgroup::
-          echo INVENTORY_PATH=$FILE >> $GITHUB_ENV
-      - name: Install server
-        run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run pe_event_forwarding::acceptance::pe_server' -- bundle exec bolt --modulepath spec/fixtures/modules plan run pe_event_forwarding::acceptance::pe_server version='${{ matrix.pe_version }}' -i ./$INVENTORY_PATH
-
-      - name: Add localhost target to inventory
-        run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'rake acceptance:add_localhost_target' -- bundle exec rake 'acceptance:add_localhost_target'
-
-      - name: Install module
-        run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_module' -- bundle exec rake 'litmus:install_module'
-
-      - name: Run tests
-        run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'rake acceptance::run_tests' -- bundle exec rake acceptance:run_tests
-
-      - name: "Honeycomb: Record deployment times"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb step
-          buildevents step $TRACE_ID $STEP_ID $STEP_START 'Deploy test system'
-          echo STEP_ID=${{ matrix.platform }}-${{ matrix.pe_version }}-3 >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
-
-      - name: Remove test environment
-        if: ${{ always() }}
-        continue-on-error: true
-        run: |
-          if [[ -f inventory.yaml || -f spec/fixtures/litmus_inventory.yaml ]]; then
-            buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
-            echo ::group::=== REQUEST ===
-            cat request.json || true
-            echo
-            echo ::endgroup::
-          fi
-      - name: "Honeycomb: Record removal times"
-        if: ${{ always() }}
-        run: |
-          buildevents step $TRACE_ID $STEP_ID $STEP_START 'Remove test environment'
+        fi

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -6,10 +6,6 @@ on:
   workflow_dispatch:
   pull_request:
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   setup_matrix:
     name: "Setup Test Matrix"
@@ -18,61 +14,28 @@ jobs:
       spec_matrix: ${{ steps.get-matrix.outputs.spec_matrix }}
 
     steps:
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
+    - name: Checkout Source
+      uses: actions/checkout@v3
+      if: ${{ github.repository_owner == 'puppetlabs' }}
 
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-environment >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
+    - name: Activate Ruby 2.7
+      uses: ruby/setup-ruby@v1
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+      with:
+        ruby-version: "2.7"
+        bundler-cache: true
 
-      - name: Checkout Source
-        uses: actions/checkout@v2
-        if: ${{ github.repository_owner == 'puppetlabs' }}
-
-      - name: Activate Ruby 2.7
-        uses: ruby/setup-ruby@v1
-        if: ${{ github.repository_owner == 'puppetlabs' }}
-        with:
-          ruby-version: "2.7"
-          bundler-cache: true
-
-      - name: Print bundle environment
-        if: ${{ github.repository_owner == 'puppetlabs' }}
-        run: |
-          echo ::group::bundler environment
-          buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record Setup Environment time"
-        if: ${{ github.repository_owner == 'puppetlabs' }}
-        run: |
-          buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
-          echo STEP_ID=Setup-Acceptance-Test-Matrix >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
-      - name: Run Static & Syntax Tests
-        if: ${{ github.repository_owner == 'puppetlabs' }}
-        run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'static_syntax_checks' -- bundle exec rake validate lint check rubocop
-
-      - name: Setup Spec Test Matrix
-        id: get-matrix
-        run: |
-          if [ '${{ github.repository_owner }}' == 'puppetlabs' ]; then
-            buildevents cmd $TRACE_ID $STEP_ID matrix_from_metadata -- bundle exec matrix_from_metadata_v2
-          else
-            echo  "::set-output name=spec_matrix::{}"
-          fi
-
-      - name: "Honeycomb: Record Setup Test Matrix time"
-        if: ${{ always() }}
-        run: |
-          buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Test Matrix'
+    - name: Print bundle environment
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+      run: |
+        echo ::group::bundler environment
+        bundle env
+        echo ::endgroup::
+    - name: Setup Spec Test Matrix
+      id: get-matrix
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+      run: |
+          bundle exec matrix_from_metadata_v2
 
   Spec:
     name: "Spec Tests (Puppet: ${{matrix.puppet_version}}, Ruby Ver: ${{matrix.ruby_version}})"
@@ -86,45 +49,28 @@ jobs:
       matrix: ${{fromJson(needs.setup_matrix.outputs.spec_matrix)}}
 
     env:
-      BUILDEVENT_FILE: '../buildevents.txt'
       PUPPET_GEM_VERSION: ${{ matrix.puppet_version }}
       FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main'
 
     steps:
-      - run: |
-          echo "SANITIZED_PUPPET_VERSION=$(echo '${{ matrix.puppet_version }}' | sed 's/~> //g')" >> $GITHUB_ENV
+    - name: Checkout Source
+      uses: actions/checkout@v3
 
-      - run: |
-          echo 'puppet_version=${{ env.SANITIZED_PUPPET_VERSION }}' >> $BUILDEVENT_FILE
+    - name: "Activate Ruby ${{ matrix.ruby_version }}"
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{matrix.ruby_version}}
+        bundler-cache: true
 
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo "STEP_ID=${{ env.SANITIZED_PUPPET_VERSION }}-spec" >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-          matrix-key: ${{ env.SANITIZED_PUPPET_VERSION }}
-
-      - name: Checkout Source
-        uses: actions/checkout@v2
-
-      - name: "Activate Ruby ${{ matrix.ruby_version }}"
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{matrix.ruby_version}}
-          bundler-cache: true
-
-      - name: Print bundle environment
-        run: |
-          echo ::group::bundler environment
-          buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: Run parallel_spec tests
-        run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'rake parallel_spec Puppet ${{ matrix.puppet_version }}, Ruby ${{ matrix.ruby_version }}' -- bundle exec rake parallel_spec
+    - name: Print bundle environment
+      run: |
+        echo ::group::bundler environment
+        bundle env
+        echo ::endgroup::
+    - name: Run Static & Syntax Tests
+      if: ${{ github.repository_owner == 'puppetlabs' }}
+      run: |
+        bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
+    - name: Run parallel_spec tests
+      run: |
+        bundle exec rake parallel_spec

--- a/.pdkignore
+++ b/.pdkignore
@@ -39,7 +39,6 @@
 /rakelib/
 /.rspec
 /.rubocop.yml
-/.travis.yml
 /.yardopts
 /spec/
 /.vscode/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 - rubocop-rspec
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.4'
+  TargetRubyVersion: '2.5'
   Include:
   - "**/*.rb"
   Exclude:
@@ -517,3 +517,4 @@ Style/RedundantArgument:
   Enabled: false
 Style/SwapValues:
   Enabled: false
+  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file. The format 
 
 [Current Diff](https://github.com/puppetlabs/puppetlabs-splunk_hec/compare/v1.1.0..main)
 
+## [v2.0.0](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/tree/v2.0.0) (2023-05-XX)
+
+### Fixed
+
+- Utilize kwargs over positional args for Ruby 3 compatibility. [#119](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/pull/119)
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/compare/v1.1.0..v2.0.0)
+
 ## [v1.1.1](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/tree/v1.1.1) (2023-01-31)
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -13,21 +13,31 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
-ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = ruby_version_segments[0..1].join('.')
-
 group :development do
-  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "json", '= 2.1.0',                           require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                           require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                           require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                           require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                           require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 4.0',   require: false
+  gem "facterdb", '~> 1.18',                       require: false
+  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0', require: false
+  gem "puppetlabs_spec_helper", '~> 5.0',          require: false
+  gem "rspec-puppet-facts", '~> 2.0',              require: false
+  gem "codecov", '~> 0.2',                         require: false
+  gem "dependency_checker", '~> 0.2',              require: false
+  gem "parallel_tests", '= 3.12.1',                require: false
+  gem "pry", '~> 0.10',                            require: false
+  gem "simplecov-console", '~> 0.5',               require: false
+  gem "puppet-debugger", '~> 1.0',                 require: false
+  gem "rubocop", '~> 1.22',                        require: false
+  gem "rubocop-performance", '= 1.9.1',            require: false
+  gem "rubocop-rspec", '= 2.0.1',                  require: false
+  gem "rb-readline", '= 0.5.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby, :x64_mingw]
+  gem "serverspec", '~> 2.41',    require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/README.md
+++ b/README.md
@@ -3,20 +3,23 @@
 #### Table of Contents
 
 
-1. [Intro](#intro)
-2. [Usage](#usage)
-3. [How it works](#how-it-works)
-4. [Writing an Event Forwarding Processor](#writing-an-event-forwarding-processor)
-5. [Installing A Processor](#installing-a-processor)
-6. [Token vs Username Password Authentication](#token-vs-username-password-authentication)
-7. [Resources Placed On The Machine](#resources-placed-on-the-machine)
-8. [Logging](#logging)
-9. [Advanced Configuration Options](#advanced-configuration-options)
+- [puppetlabs-pe\_event\_forwarding](#puppetlabs-pe_event_forwarding)
+      - [Table of Contents](#table-of-contents)
+  - [Intro](#intro)
+  - [Usage](#usage)
+    - [Forwarding from non server nodes](#forwarding-from-non-server-nodes)
+  - [How it works](#how-it-works)
+  - [Compatible PE Versions](#compatible-pe-versions)
+  - [Writing an Event Forwarding Processor](#writing-an-event-forwarding-processor)
+  - [Installing A Processor](#installing-a-processor)
+  - [Token vs Username Password Authentication](#token-vs-username-password-authentication)
+  - [Resources Placed On The Machine](#resources-placed-on-the-machine)
+  - [Logging](#logging)
+  - [Advanced Configuration Options](#advanced-configuration-options)
 
 ## Intro
 
 This module gathers events from the [Puppet Jobs API][1] and the [Activities API][2] using a script executed by a cron job. This data is provided to any available processor scripts during each run. The scripts are provided by any modules that want to make use of this data such as the [puppetlabs-splunk_hec][3] module. These processor scripts then handle the data they are given and forward it on to their respective platforms.
-
 
 ## Usage
 
@@ -52,9 +55,9 @@ This module is capable of gathering events data and invoking processors from non
 
 ## Compatible PE Versions
 
-This module is compatible with PE versions in the 2019 range starting at 2019.8.7 and above, and then 2021 versions from 2021.2 and above.
+This module is compatible with PE versions `>= 2021.2`.
 
-Versions in the PE 2019 series below 2019.8.7 and in the 2021 series in versions below 2021.2 did not recieve an update to some of the API methods in PE that are required for this module to function properly.
+> Starting with **`v2.0.0`, this module no longer supports PE 2019.8.12**.
 
 ## Writing an Event Forwarding Processor
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10,7 +10,7 @@
 
 ### Functions
 
-* [`pe_event_forwarding::base_path`](#pe_event_forwardingbase_path): This custom function returns the base path of any given string argument. If a desired path is not passed in, it will match the default str ar
+* [`pe_event_forwarding::base_path`](#pe_event_forwarding--base_path): This custom function returns the base path of any given string argument. If a desired path is not passed in, it will match the default str ar
 
 ### Tasks
 
@@ -19,8 +19,8 @@
 
 ### Plans
 
-* [`pe_event_forwarding::acceptance::pe_server`](#pe_event_forwardingacceptancepe_server): Install PE Server
-* [`pe_event_forwarding::acceptance::provision_machines`](#pe_event_forwardingacceptanceprovision_machines): Provisions machines
+* [`pe_event_forwarding::acceptance::pe_server`](#pe_event_forwarding--acceptance--pe_server): Install PE Server
+* [`pe_event_forwarding::acceptance::provision_machines`](#pe_event_forwarding--acceptance--provision_machines): Provisions machines
 
 ## Classes
 
@@ -41,48 +41,49 @@ include pe_event_forwarding
 
 The following parameters are available in the `pe_event_forwarding` class:
 
-* [`pe_username`](#pe_username)
-* [`pe_password`](#pe_password)
-* [`pe_token`](#pe_token)
-* [`pe_console`](#pe_console)
-* [`disabled`](#disabled)
-* [`cron_minute`](#cron_minute)
-* [`cron_hour`](#cron_hour)
-* [`cron_weekday`](#cron_weekday)
-* [`cron_month`](#cron_month)
-* [`cron_monthday`](#cron_monthday)
-* [`log_path`](#log_path)
-* [`lock_path`](#lock_path)
-* [`confdir`](#confdir)
-* [`api_page_size`](#api_page_size)
-* [`log_level`](#log_level)
-* [`log_rotation`](#log_rotation)
+* [`pe_username`](#-pe_event_forwarding--pe_username)
+* [`pe_password`](#-pe_event_forwarding--pe_password)
+* [`pe_token`](#-pe_event_forwarding--pe_token)
+* [`pe_console`](#-pe_event_forwarding--pe_console)
+* [`disabled`](#-pe_event_forwarding--disabled)
+* [`cron_minute`](#-pe_event_forwarding--cron_minute)
+* [`cron_hour`](#-pe_event_forwarding--cron_hour)
+* [`cron_weekday`](#-pe_event_forwarding--cron_weekday)
+* [`cron_month`](#-pe_event_forwarding--cron_month)
+* [`cron_monthday`](#-pe_event_forwarding--cron_monthday)
+* [`log_path`](#-pe_event_forwarding--log_path)
+* [`lock_path`](#-pe_event_forwarding--lock_path)
+* [`confdir`](#-pe_event_forwarding--confdir)
+* [`api_page_size`](#-pe_event_forwarding--api_page_size)
+* [`log_level`](#-pe_event_forwarding--log_level)
+* [`log_rotation`](#-pe_event_forwarding--log_rotation)
+* [`disable_rbac`](#-pe_event_forwarding--disable_rbac)
 
-##### <a name="pe_username"></a>`pe_username`
+##### <a name="-pe_event_forwarding--pe_username"></a>`pe_username`
 
 Data type: `Optional[String]`
 
 PE username
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="pe_password"></a>`pe_password`
+##### <a name="-pe_event_forwarding--pe_password"></a>`pe_password`
 
 Data type: `Optional[Sensitive[String]]`
 
 PE password
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="pe_token"></a>`pe_token`
+##### <a name="-pe_event_forwarding--pe_token"></a>`pe_token`
 
 Data type: `Optional[String]`
 
 PE token
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="pe_console"></a>`pe_console`
+##### <a name="-pe_event_forwarding--pe_console"></a>`pe_console`
 
 Data type: `Optional[String]`
 
@@ -90,15 +91,15 @@ PE console
 
 Default value: `'localhost'`
 
-##### <a name="disabled"></a>`disabled`
+##### <a name="-pe_event_forwarding--disabled"></a>`disabled`
 
 Data type: `Optional[Boolean]`
 
 When true, removes cron job
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="cron_minute"></a>`cron_minute`
+##### <a name="-pe_event_forwarding--cron_minute"></a>`cron_minute`
 
 Data type: `Optional[String]`
 
@@ -106,7 +107,7 @@ Sets cron minute (0-59)
 
 Default value: `'*/2'`
 
-##### <a name="cron_hour"></a>`cron_hour`
+##### <a name="-pe_event_forwarding--cron_hour"></a>`cron_hour`
 
 Data type: `Optional[String]`
 
@@ -114,7 +115,7 @@ Sets cron hour (0-23)
 
 Default value: `'*'`
 
-##### <a name="cron_weekday"></a>`cron_weekday`
+##### <a name="-pe_event_forwarding--cron_weekday"></a>`cron_weekday`
 
 Data type: `Optional[String]`
 
@@ -122,7 +123,7 @@ Sets cron day of the week (0-6)
 
 Default value: `'*'`
 
-##### <a name="cron_month"></a>`cron_month`
+##### <a name="-pe_event_forwarding--cron_month"></a>`cron_month`
 
 Data type: `Optional[String]`
 
@@ -130,7 +131,7 @@ Sets cron month (1-12)
 
 Default value: `'*'`
 
-##### <a name="cron_monthday"></a>`cron_monthday`
+##### <a name="-pe_event_forwarding--cron_monthday"></a>`cron_monthday`
 
 Data type: `Optional[String]`
 
@@ -138,41 +139,41 @@ Sets cron day of the month (1-31)
 
 Default value: `'*'`
 
-##### <a name="log_path"></a>`log_path`
+##### <a name="-pe_event_forwarding--log_path"></a>`log_path`
 
 Data type: `Optional[String]`
 
 Should be a directory; base path to desired location for log files
 `/pe_event_forwarding/pe_event_forwarding.log` will be appended to this param
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="lock_path"></a>`lock_path`
+##### <a name="-pe_event_forwarding--lock_path"></a>`lock_path`
 
 Data type: `Optional[String]`
 
 Should be a directory; base path to desired location for lock file
 `/pe_event_forwarding/cache/state/events_collection_run.lock` will be appended to this param
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="confdir"></a>`confdir`
+##### <a name="-pe_event_forwarding--confdir"></a>`confdir`
 
 Data type: `Optional[String]`
 
 Path to directory where pe_event_forwarding exists
 
-Default value: `"${pe_event_forwarding::base_path($settings::confdir,undef)}/pe_event_forwarding"`
+Default value: `undef`
 
-##### <a name="api_page_size"></a>`api_page_size`
+##### <a name="-pe_event_forwarding--api_page_size"></a>`api_page_size`
 
 Data type: `Optional[Integer]`
 
 Sets max number of events retrieved per API call
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="log_level"></a>`log_level`
+##### <a name="-pe_event_forwarding--log_level"></a>`log_level`
 
 Data type: `Enum['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL']`
 
@@ -184,7 +185,7 @@ Determines the severity of logs to be written to log file:
 
 Default value: `'WARN'`
 
-##### <a name="log_rotation"></a>`log_rotation`
+##### <a name="-pe_event_forwarding--log_rotation"></a>`log_rotation`
 
 Data type: `Enum['NONE', 'DAILY', 'WEEKLY', 'MONTHLY']`
 
@@ -192,9 +193,17 @@ Determines rotation time for log files
 
 Default value: `'NONE'`
 
+##### <a name="-pe_event_forwarding--disable_rbac"></a>`disable_rbac`
+
+Data type: `Boolean`
+
+When true, all RBAC events will be skipped from collection
+
+Default value: `false`
+
 ## Functions
 
-### <a name="pe_event_forwardingbase_path"></a>`pe_event_forwarding::base_path`
+### <a name="pe_event_forwarding--base_path"></a>`pe_event_forwarding::base_path`
 
 Type: Ruby 4.x API
 
@@ -318,7 +327,7 @@ Nodes to run facts on. Different from console host target
 
 ## Plans
 
-### <a name="pe_event_forwardingacceptancepe_server"></a>`pe_event_forwarding::acceptance::pe_server`
+### <a name="pe_event_forwarding--acceptance--pe_server"></a>`pe_event_forwarding::acceptance::pe_server`
 
 Install PE Server
 
@@ -334,10 +343,10 @@ pe_event_forwarding::acceptance::pe_server
 
 The following parameters are available in the `pe_event_forwarding::acceptance::pe_server` plan:
 
-* [`version`](#version)
-* [`pe_settings`](#pe_settings)
+* [`version`](#-pe_event_forwarding--acceptance--pe_server--version)
+* [`pe_settings`](#-pe_event_forwarding--acceptance--pe_server--pe_settings)
 
-##### <a name="version"></a>`version`
+##### <a name="-pe_event_forwarding--acceptance--pe_server--version"></a>`version`
 
 Data type: `Optional[String]`
 
@@ -345,7 +354,7 @@ PE version
 
 Default value: `'2019.8.7'`
 
-##### <a name="pe_settings"></a>`pe_settings`
+##### <a name="-pe_event_forwarding--acceptance--pe_server--pe_settings"></a>`pe_settings`
 
 Data type: `Optional[Hash]`
 
@@ -353,7 +362,7 @@ Hash with key `password` and value of PE console password for admin user
 
 Default value: `{password => 'puppetlabs'}`
 
-### <a name="pe_event_forwardingacceptanceprovision_machines"></a>`pe_event_forwarding::acceptance::provision_machines`
+### <a name="pe_event_forwarding--acceptance--provision_machines"></a>`pe_event_forwarding::acceptance::provision_machines`
 
 Provisions machines
 
@@ -361,10 +370,10 @@ Provisions machines
 
 The following parameters are available in the `pe_event_forwarding::acceptance::provision_machines` plan:
 
-* [`using`](#using)
-* [`image`](#image)
+* [`using`](#-pe_event_forwarding--acceptance--provision_machines--using)
+* [`image`](#-pe_event_forwarding--acceptance--provision_machines--image)
 
-##### <a name="using"></a>`using`
+##### <a name="-pe_event_forwarding--acceptance--provision_machines--using"></a>`using`
 
 Data type: `Optional[String]`
 
@@ -372,11 +381,10 @@ provision service
 
 Default value: `'abs'`
 
-##### <a name="image"></a>`image`
+##### <a name="-pe_event_forwarding--acceptance--provision_machines--image"></a>`image`
 
 Data type: `Optional[String]`
 
 os image
 
 Default value: `'centos-7-x86_64'`
-

--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,7 @@ end
 
 PuppetLint.configuration.send('disable_relative')
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
@@ -85,4 +86,3 @@ Gemfile:
 EOM
   end
 end
-

--- a/files/collect_api_events.rb
+++ b/files/collect_api_events.rb
@@ -47,7 +47,7 @@ def main(confdir, logpath, lockdir)
   orchestrator = PeEventForwarding::Orchestrator.new(settings['pe_console'], client_options)
   activities = PeEventForwarding::Activity.new(settings['pe_console'], client_options)
 
-  service_names = settings['disable_rbac'] == 'false' ? PeEventForwarding::Activity::SERVICE_NAMES_WITH_RBAC : PeEventForwarding::Activity::SERVICE_NAMES_WITHOUT_RBAC
+  service_names = (settings['disable_rbac'] == 'false') ? PeEventForwarding::Activity::SERVICE_NAMES_WITH_RBAC : PeEventForwarding::Activity::SERVICE_NAMES_WITHOUT_RBAC
 
   if index.first_run?
     data[:orchestrator] = orchestrator.current_job_count
@@ -97,8 +97,8 @@ def main(confdir, logpath, lockdir)
       start_time = Time.now
       processor.invoke(data)
       duration = Time.now - start_time
-      log.info(processor.stdout, source: processor.name) unless processor.stdout.length.zero?
-      log.warn(processor.stderr, source: processor.name, exit_code: processor.exitcode) unless processor.stderr.length.zero? && processor.exitcode == 0
+      log.info(processor.stdout, source: processor.name) unless processor.stdout.empty?
+      log.warn(processor.stderr, source: processor.name, exit_code: processor.exitcode) unless processor.stderr.empty? && processor.exitcode == 0
       log.info("#{processor.name} finished: #{duration} second(s) to complete.")
     end
     index.save(data)

--- a/files/util/index.rb
+++ b/files/util/index.rb
@@ -26,9 +26,9 @@ module PeEventForwarding
 
     def counts(refresh: false)
       if refresh
-        @counts = YAML.safe_load(File.read(filepath), [Symbol])
+        @counts = YAML.safe_load(File.read(filepath), permitted_classes: [Symbol])
       end
-      @counts ||= YAML.safe_load(File.read(filepath), [Symbol])
+      @counts ||= YAML.safe_load(File.read(filepath), permitted_classes: [Symbol])
     end
 
     def count(service)

--- a/files/util/logger.rb
+++ b/files/util/logger.rb
@@ -13,7 +13,7 @@ module PeEventForwarding
     }.freeze
 
     def initialize(log_path, shift_age)
-      shift_age = shift_age == 'NONE' ? 0 : shift_age.downcase
+      shift_age = (shift_age == 'NONE') ? 0 : shift_age.downcase
       super(log_path, shift_age)
       self.datetime_format = '%Y-%m-%d %H:%M:%S'
 

--- a/lib/puppet/functions/pe_event_forwarding/base_path.rb
+++ b/lib/puppet/functions/pe_event_forwarding/base_path.rb
@@ -11,7 +11,7 @@ Puppet::Functions.create_function(:'pe_event_forwarding::base_path') do
     # No specific path is provided, going to use default path from logdir
     if path.nil?
       base = str.match(%r{^(.*?\/puppetlabs)\/})
-      !base.nil? ? base[1] : str
+      (!base.nil?) ? base[1] : str
     # A specfic path is provided
     else
       path

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,17 +44,19 @@
 #    - level fatal will only log fatal-level log messages
 # @param [Enum['NONE', 'DAILY', 'WEEKLY', 'MONTHLY']] log_rotation
 #   Determines rotation time for log files
+# @param [Boolean] disable_rbac
+#   When true, all RBAC events will be skipped from collection
 class pe_event_forwarding (
   Optional[String]                                $pe_username            = undef,
   Optional[Sensitive[String]]                     $pe_password            = undef,
   Optional[String]                                $pe_token               = undef,
-  Optional[String]                                $pe_console             = 'localhost',
-  Optional[Boolean]                               $disabled               = false,
-  Optional[String]                                $cron_minute            = '*/2',
-  Optional[String]                                $cron_hour              = '*',
-  Optional[String]                                $cron_weekday           = '*',
-  Optional[String]                                $cron_month             = '*',
-  Optional[String]                                $cron_monthday          = '*',
+  String                                          $pe_console             = 'localhost',
+  Boolean                                         $disabled               = false,
+  String                                          $cron_minute            = '*/2',
+  String                                          $cron_hour              = '*',
+  String                                          $cron_weekday           = '*',
+  String                                          $cron_month             = '*',
+  String                                          $cron_monthday          = '*',
   Optional[String]                                $log_path               = undef,
   Optional[String]                                $lock_path              = undef,
   Optional[String]                                $confdir                = undef,
@@ -62,18 +64,18 @@ class pe_event_forwarding (
   Enum['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'] $log_level              = 'WARN',
   Enum['NONE', 'DAILY', 'WEEKLY', 'MONTHLY']      $log_rotation           = 'NONE',
   Boolean                                         $disable_rbac           = false,
-){
-
+) {
+  # Ensure required credential params are configured
   if (
     ($pe_token == undef)
     and
     ($pe_username == undef or $pe_password == undef)
   ) {
     $authorization_failure_message = @(MESSAGE/L)
-    Please set both 'pe_username' and 'pe_password' \
-    if you are not using a pre generated PE authorization \
-    token in the 'pe_token' parameter
-    |-MESSAGE
+      Please set both 'pe_username' and 'pe_password' \
+      if you are not using a pre generated PE authorization \
+      token in the 'pe_token' parameter
+      |-MESSAGE
     fail($authorization_failure_message)
   }
 
@@ -109,7 +111,7 @@ class pe_event_forwarding (
     "${logfile_basepath}/pe_event_forwarding",
     "${lockdir_basepath}/pe_event_forwarding",
     "${lockdir_basepath}/pe_event_forwarding/cache/",
-    "${lockdir_basepath}/pe_event_forwarding/cache/state"
+    "${lockdir_basepath}/pe_event_forwarding/cache/state",
   ]
 
   cron { 'collect_pe_events':

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
   "name": "puppetlabs-pe_event_forwarding",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "author": "Puppet, Inc.",
   "summary": "A module that contains support for integration event reporting",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-pe_event_forwarding",
   "project_page": "https://github.com/puppetlabs/puppetlabs-pe_event_forwarding",
-  "issues_url": "https://tickets.puppetlabs.com/projects/PIE/issues",
+  "issues_url": "https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/issues",
   "dependencies": [
     {
       "name": "puppetlabs/ruby_task_helper",
@@ -17,15 +17,13 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {
@@ -38,30 +36,31 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
+        "20.04",
         "18.04"
       ]
     },
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "12"
+        "12",
+        "15"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.23.0 < 8.0.0"
+      "version_requirement": ">= 7.8.0 < 9.0.0"
     }
   ],
-  "pdk-version": "2.2.0",
-  "template-url": "pdk-default#2.2.0",
-  "template-ref": "tags/2.2.0-0-g2381db6"
+  "pdk-version": "2.7.1",
+  "template-url": "pdk-default#2.7.4",
+  "template-ref": "tags/2.7.4-0-g58edf57"
 }

--- a/plans/acceptance/pe_server.pp
+++ b/plans/acceptance/pe_server.pp
@@ -10,12 +10,12 @@
 # @param pe_settings
 #   Hash with key `password` and value of PE console password for admin user
 plan pe_event_forwarding::acceptance::pe_server(
-  Optional[String] $version = '2019.8.7',
-  Optional[Hash] $pe_settings = {password => 'puppetlabs'}
+  Optional[String] $version = '2021.7.3',
+  Optional[Hash] $pe_settings = { password => 'puppetlabspie' }
 ) {
-  # machines are not yet ready at time of installing the puppetserver, so we wait 15s
+  # machines are not yet ready at time of installing the puppetserver, so we wait 30s
   $localhost = get_targets('localhost')
-  run_command('sleep 15s', $localhost)
+  run_command('sleep 30s', $localhost)
 
   #identify pe server node
   $puppet_server =  get_targets('*').filter |$n| { $n.vars['role'] == 'server' }
@@ -29,11 +29,10 @@ plan pe_event_forwarding::acceptance::pe_server(
   )
 
   $cmd = @("CMD")
-          puppet infra console_password --password=pie
-          echo 'pie' | puppet access login --lifetime 1y --username admin
-          puppet infrastructure tune | sed "s,\\x1B\\[[0-9;]*[a-zA-Z],,g" > /etc/puppetlabs/code/environments/production/data/common.yaml
-          puppet agent -t
-          | CMD
+    echo 'puppetlabspie' | puppet access login --lifetime 1y --username admin
+    puppet infrastructure tune | sed "s,\\x1B\\[[0-9;]*[a-zA-Z],,g" > /etc/puppetlabs/code/environments/production/data/common.yaml
+    puppet agent -t
+    | CMD
 
   run_command($cmd, $puppet_server, '_catch_errors' => true)
 }

--- a/plans/acceptance/provision_machines.pp
+++ b/plans/acceptance/provision_machines.pp
@@ -9,5 +9,5 @@ plan pe_event_forwarding::acceptance::provision_machines(
   Optional[String] $image = 'centos-7-x86_64'
 ) {
   # provision machines, set roles
-    run_task("provision::${using}", 'localhost', action => 'provision', platform => $image, vars => 'role: server')
+  run_task("provision::${using}", 'localhost', action => 'provision', platform => $image, vars => 'role: server')
 }

--- a/rakelib/helpers.rake
+++ b/rakelib/helpers.rake
@@ -100,7 +100,6 @@ namespace :acceptance do
   desc 'Runs the tests'
   task :run_tests do
     rspec_command  = 'bundle exec rspec ./spec/acceptance --format documentation'
-    rspec_command += ' --format RspecJunitFormatter --out rspec_junit_results.xml' if ENV['CI'] == 'true'
     puts("Running the tests ...\n")
     unless system(rspec_command)
       # system returned false which means rspec failed. So exit 1 here

--- a/spec/acceptance/index_spec.rb
+++ b/spec/acceptance/index_spec.rb
@@ -22,7 +22,7 @@ describe 'index file' do
     index_contents = puppetserver.run_shell("cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
     index          = YAML.safe_load(index_contents, [Symbol])
     current_value  = index[:orchestrator]
-    puppetserver.run_shell("puppet task run facts --nodes #{console_host_fqdn}")
+    puppetserver.run_shell("LC_ALL=en_US.UTF-8 puppet task run facts --nodes #{console_host_fqdn}")
     index_contents = puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb ; cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
     index = YAML.safe_load(index_contents, [Symbol])
     updated_value = index[:orchestrator]

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -32,7 +32,7 @@ def index_data(**custom_count)
 end
 
 def index_yaml(**custom_count)
-  index_data(custom_count).to_yaml
+  index_data(**custom_count).to_yaml
 end
 
 def events_data(**extra_data)


### PR DESCRIPTION
# Summary

This commit contains changes made by `pdk`, `rubocop` and `lint`;  as well as manual changes to `metadata.json` to add Puppet 8.

Honeycomb steps have been removed from workflows `spec.yml` and `integration_test.yml`.

# Detailed Description

  * **PDK Update**:
    * `.devcontainer/devcontainer.json`
    * `.rubocop.yml`
    *  `.pdkignore`
    * `Rakefile`
    * `Gemfile`
    * `.github/workflows/spec.yml`
 
  * **Rubocop Changes**:
    * `plans/acceptance/provision_machines.pp`
    * `plans/acceptance/pe_server.pp`
    * `lib/puppet/functions/pe_event_forwarding/base_path.rb`
    * `files/util/logger.rb`
    * `files/collect_api_events.rb`

  * **Lint Changes**:
    * `manifests/init.pp`

---

**Maint Changes**:

  * `README.md`
    * Add note about `v2` removing support for PE 2019.8.12.

  * `metadata.json`
    * Bumped module to `v2`. 
    * Added Puppet 8 / Pulled Puppet 6 / Updated supported OS list.

  * `.github/workflows/integration_test.yml`
    * Set `PUPPET_GEM_VERSION` to Puppet 7.
    * Update PE version to current LTS (2021.7.2).
    * Removed Honeycomb steps.
 
  * `.github/workflows/spec.yml`
    * Removed Honeycomb steps.

  * `spec/acceptance/index_spec.rb`
    * Fix `locale` error.

  * `rakelib/helpers.rake`
    * Remove use of `RspecJunitFormatter`.

  * `plans/acceptance/pe_server.pp`
    * Set admin pass during install.
    * Bump PE version.

---

**Ruby 3 Changes**:

  * `spec/spec_helper_local.rb`
    *  Add double splat (`**`)  to pass keyword args instead of Hash object.
  
  * `files/util/index.rb`
    * `YAML#safe_load` keyword args.

---