### PR TITLE
(PIE-1313) Add spec tests for base_path function

### DIFF
--- a/spec/functions/base_path_spec.rb
+++ b/spec/functions/base_path_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'pe_event_forwarding::base_path' do
+  context 'w/ user provided params' do
+    it { is_expected.to run.with_params(nil, '/tmp/').and_return('/tmp') }
+    it { is_expected.to run.with_params(nil, '/tmp/conf').and_return('/tmp/conf') }
+    it { is_expected.to run.with_params(CONFDIR, '/tmp/pie/conf').and_return('/tmp/pie/conf') }
+  end
+
+  context 'w/ default params' do
+    it { is_expected.to run.with_params(CONFDIR, nil).and_return('/etc/puppetlabs') }
+    it { is_expected.to run.with_params(LOGDIR, nil).and_return('/var/log/puppetlabs') }
+    it { is_expected.to run.with_params(LOCKFILEDIR, nil).and_return('/opt/puppetlabs') }
+  end
+end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,3 +1,7 @@
+CONFDIR = '/etc/puppetlabs/puppet'.freeze
+LOGDIR  = '/var/log/puppetlabs/puppet'.freeze
+LOCKFILEDIR = '/opt/puppetlabs/puppet/cache/state'.freeze
+
 RSpec.configure do |c|
   c.mock_with :rspec
 end


### PR DESCRIPTION
# Summary

Adding spec tests for the `base_path` function after removing the MockFunction from `splunk_hec`.

# Detailed Description

  * Added `spec/functions/base_path_spec.rb`
  * Updated `spec/spec_helper_local.rb` to set default dir paths.