### PR TITLE
(PIE-1462) Add timeout parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 
+- Added parameter `pe_event_forwarding::timeout` to configure optional HTTP timeout. [#126](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/pull/126)
+
 - Added parameters `pe_event_forwarding::skip_events` and `pe_event_forwarding::skip_jobs` to disable collection by service. [#124](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/pull/124)
 
 - Credential data provided to this module is now written to a separate settings file utilizing the `Sensitive` data type to ensure redaction from Puppet logs and reports. [#122](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/pull/122)

--- a/README.md
+++ b/README.md
@@ -211,8 +211,6 @@ This module will allow administators to use `pe_username` and `pe_password` para
 
 To prevent these unnecessary events, it is recommended that administrators create a dedicated user in the console and [generate a long lived token][4] to use with the `pe_token` parameter instead. Using a pre-generated token will prevent these unwanted events from being generated.
 
-Also note that the `pe_password` parameter is a [`Sensitive`][8] parameter. The value for this parameter cannot be assigned through the console. You can use the `Sensitive()` function in a manifest to provide a value, or you can use [`lookup_options` in Hiera][9] to assign the value.
-
 ## Resources Placed On The Machine
 
 When this module is classified to a Puppet Server it will create a set of resources on the system.
@@ -229,7 +227,9 @@ Inside that directory will be:
 
 - The events collection script `collect_api_events.rb`.
 
-- A configuration settings file `events_collection.yaml`.
+- A configuration settings file `collection_settings.yaml`.
+
+- A credential settings file `collection_secrets.yaml`
 
 - An index tracking file `pe_event_forwarding_indexes.yaml`.
 
@@ -280,6 +280,14 @@ Setting this variable to true will skip all orchestrator events. This is useful 
 Use these parameters to set a custom schedule for gathering events and executing processors. This schedule is enforced for the overall PE Event Forwarding feature. This means that all processors will be executing on this schedule, and the individual platform processors have no control over how often they are invoked. The default parameter values result in a cron schedule that invokes events collection every two minutes `*/2 * * * *`. Administators can use this parameter set to reduce the cycle interval to every minute, or to increase the interval to collect less often.
 
 The Events Collection script can detect if a previous collection cycle is not complete. If this happens the script will log a message and exit to let the previous cycle finish. The log file (see below for log file placement) logs the amount of time each collection cycle took, and this duration can be used to adjust the cron interval to an appropriate value.
+
+--------------------------------------------------------------------------------
+
+`timeout`
+
+This optional parameter can be set to change the HTTP timeout used when collection events from the Activity and Orchestrator APIs. By default the timeout is `60` seconds.
+
+If configured, the timeout should not exceed the collection interval set with the `cron_minute` parameter.
 
 --------------------------------------------------------------------------------
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -48,24 +48,76 @@ include pe_event_forwarding
 
 The following parameters are available in the `pe_event_forwarding` class:
 
-* [`pe_username`](#-pe_event_forwarding--pe_username)
-* [`pe_password`](#-pe_event_forwarding--pe_password)
-* [`pe_token`](#-pe_event_forwarding--pe_token)
-* [`pe_console`](#-pe_event_forwarding--pe_console)
-* [`disabled`](#-pe_event_forwarding--disabled)
-* [`cron_minute`](#-pe_event_forwarding--cron_minute)
-* [`cron_hour`](#-pe_event_forwarding--cron_hour)
-* [`cron_weekday`](#-pe_event_forwarding--cron_weekday)
-* [`cron_month`](#-pe_event_forwarding--cron_month)
-* [`cron_monthday`](#-pe_event_forwarding--cron_monthday)
-* [`log_path`](#-pe_event_forwarding--log_path)
-* [`lock_path`](#-pe_event_forwarding--lock_path)
-* [`confdir`](#-pe_event_forwarding--confdir)
-* [`api_page_size`](#-pe_event_forwarding--api_page_size)
-* [`log_level`](#-pe_event_forwarding--log_level)
-* [`log_rotation`](#-pe_event_forwarding--log_rotation)
-* [`skip_events`](#-pe_event_forwarding--skip_events)
-* [`skip_jobs`](#-pe_event_forwarding--skip_jobs)
+- [Reference](#reference)
+  - [Table of Contents](#table-of-contents)
+    - [Classes](#classes)
+      - [Public Classes](#public-classes)
+      - [Private Classes](#private-classes)
+    - [Functions](#functions)
+    - [Tasks](#tasks)
+    - [Plans](#plans)
+  - [Classes](#classes-1)
+    - [`pe_event_forwarding`](#pe_event_forwarding)
+      - [Examples](#examples)
+        - [](#)
+      - [Parameters](#parameters)
+        - [`pe_username`](#pe_username)
+        - [`pe_password`](#pe_password)
+        - [`pe_token`](#pe_token)
+        - [`pe_console`](#pe_console)
+        - [`disabled`](#disabled)
+        - [`cron_minute`](#cron_minute)
+        - [`cron_hour`](#cron_hour)
+        - [`cron_weekday`](#cron_weekday)
+        - [`cron_month`](#cron_month)
+        - [`cron_monthday`](#cron_monthday)
+        - [`timeout`](#timeout)
+        - [`log_path`](#log_path)
+        - [`lock_path`](#lock_path)
+        - [`confdir`](#confdir)
+        - [`api_page_size`](#api_page_size)
+        - [`log_level`](#log_level)
+        - [`log_rotation`](#log_rotation)
+        - [`skip_events`](#skip_events)
+        - [`skip_jobs`](#skip_jobs)
+  - [Functions](#functions-1)
+    - [`pe_event_forwarding::base_path`](#pe_event_forwardingbase_path)
+      - [Examples](#examples-1)
+        - [Calling the function](#calling-the-function)
+      - [`pe_event_forwarding::base_path(Any $str, Any $path)`](#pe_event_forwardingbase_pathany-str-any-path)
+        - [Examples](#examples-2)
+          - [Calling the function](#calling-the-function-1)
+        - [`str`](#str)
+        - [`path`](#path)
+    - [`pe_event_forwarding::secure`](#pe_event_forwardingsecure)
+      - [`pe_event_forwarding::secure(Hash $secrets)`](#pe_event_forwardingsecurehash-secrets)
+        - [`secrets`](#secrets)
+  - [Tasks](#tasks-1)
+    - [`activities`](#activities)
+      - [Parameters](#parameters-1)
+        - [`pe_console`](#pe_console-1)
+        - [`pe_username`](#pe_username-1)
+        - [`pe_password`](#pe_password-1)
+    - [`orchestrator`](#orchestrator)
+      - [Parameters](#parameters-2)
+        - [`console_host`](#console_host)
+        - [`username`](#username)
+        - [`password`](#password)
+        - [`token`](#token)
+        - [`operation`](#operation)
+        - [`body`](#body)
+        - [`nodes`](#nodes)
+  - [Plans](#plans-1)
+    - [`pe_event_forwarding::acceptance::pe_server`](#pe_event_forwardingacceptancepe_server)
+      - [Examples](#examples-3)
+        - [](#-1)
+      - [Parameters](#parameters-3)
+        - [`version`](#version)
+        - [`pe_settings`](#pe_settings)
+    - [`pe_event_forwarding::acceptance::provision_machines`](#pe_event_forwardingacceptanceprovision_machines)
+      - [Parameters](#parameters-4)
+        - [`using`](#using)
+        - [`image`](#image)
 
 ##### <a name="-pe_event_forwarding--pe_username"></a>`pe_username`
 
@@ -146,6 +198,15 @@ Data type: `String`
 Sets cron day of the month (1-31)
 
 Default value: `'*'`
+
+##### <a name="-pe_event_forwarding--timeout"></a>`timeout`
+
+Data type: `Optional[Integer]`
+
+Optional timeout limit for connect, read, and ssl sessions
+When set to `undef` the default of 60 seconds will be used
+
+Default value: `undef`
 
 ##### <a name="-pe_event_forwarding--log_path"></a>`log_path`
 

--- a/files/api/activity.rb
+++ b/files/api/activity.rb
@@ -13,7 +13,7 @@ module PeEventForwarding
       @log = log
     end
 
-    def get_events(service: nil, offset: 0, order: 'asc', api_page_size: nil)
+    def get_events(service: nil, offset: 0, order: 'asc', api_page_size: nil, timeout: nil)
       params = {
         service_id: service,
         limit:      api_page_size,
@@ -26,7 +26,7 @@ module PeEventForwarding
       response       = ''
       total_count    = 0
       loop do
-        response       = pe_client.pe_get_request(API_END_POINT, params)
+        response       = pe_client.pe_get_request(API_END_POINT, params, timeout)
         response_body  = JSON.parse(response.body)
         total_count    = response_body['pagination']['total']
         response_body['commits']&.map { |commit| response_items << commit }
@@ -39,24 +39,24 @@ module PeEventForwarding
       { 'api_total_count' => total_count, 'events' => response_items }
     end
 
-    def current_event_count(service_name)
+    def current_event_count(service_name, timeout)
       params = {
         service_id: service_name,
         limit:      1,
         offset:     0,
         order:      'asc',
       }
-      response = pe_client.pe_get_request(API_END_POINT, params)
+      response = pe_client.pe_get_request(API_END_POINT, params, timeout)
       raise 'Events API request failed' unless response.code == '200'
       events_count_for_service = JSON.parse(response.body)
       events_count_for_service['pagination']['total'] || 0
     end
 
-    def new_data(service, last_count, api_page_size)
-      new_count = current_event_count(service) - last_count
+    def new_data(service, last_count, api_page_size, timeout)
+      new_count = current_event_count(service, timeout) - last_count
       log.debug("New Event Count: #{service}: #{new_count}")
       return unless new_count > 0
-      get_events(service: service, offset: last_count, api_page_size: api_page_size)
+      get_events(service: service, offset: last_count, api_page_size: api_page_size, timeout: timeout)
     end
   end
 end

--- a/files/util/http.rb
+++ b/files/util/http.rb
@@ -45,7 +45,7 @@ module PeEventForwarding
 
     # post_request takes a uri(string), headers(optional(hash)), and a timeout(optional(int)).
     # Basic auth will be used if provided.
-    def get_request(uri, headers = {}, timeout = 60)
+    def get_request(uri, timeout, headers = {})
       headers['Content-Type'] = 'application/json' unless headers.key? 'Content-Type'
       url = URI.parse("#{hostname_with_port}/#{uri}")
       verify_mode = ssl_verify ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
@@ -55,10 +55,10 @@ module PeEventForwarding
         use_ssl: url.scheme == 'https',
         verify_mode: verify_mode,
         ca_cert: ca_cert_path,
-        read_timeout:    timeout,
-        connect_timeout: timeout,
-        ssl_timeout:     timeout,
-        write_timeout:   timeout,
+        read_timeout:    timeout.to_i,
+        connect_timeout: timeout.to_i,
+        ssl_timeout:     timeout.to_i,
+        write_timeout:   timeout.to_i,
       )
       request = Net::HTTP::Get.new(url.request_uri, headers)
 

--- a/files/util/pe_http.rb
+++ b/files/util/pe_http.rb
@@ -29,10 +29,10 @@ module PeEventForwarding
     end
 
     # Wrapper method for get_request that includes a token auth header for PE.
-    def pe_get_request(uri, params, headers = {}, timeout = 60)
-      log.debug("PE Get Request: #{uri} params: #{params}")
+    def pe_get_request(uri, params, timeout, headers = {})
+      log.debug("PE Get Request: #{uri} params: #{params} request_timeout: #{timeout}")
       uri = Http.make_params(uri, params)
-      get_request(uri, headers.merge(pe_auth_header), timeout)
+      get_request(uri, timeout, headers.merge(pe_auth_header))
     end
 
     # Wrapper method for post_request that includes a token auth header for PE.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,9 @@
 #   Sets cron month (1-12)
 # @param [Optional[String]] cron_monthday
 #   Sets cron day of the month (1-31)
+# @param [Optional[Integer]] timeout
+#   Optional timeout limit in seconds for connect, read, and ssl sessions
+#   When set to `undef` the default of 60 seconds will be used
 # @param [Optional[String]] log_path
 #   Should be a directory; base path to desired location for log files
 #   `/pe_event_forwarding/pe_event_forwarding.log` will be appended to this param
@@ -60,6 +63,7 @@ class pe_event_forwarding (
   String                                          $cron_weekday           = '*',
   String                                          $cron_month             = '*',
   String                                          $cron_monthday          = '*',
+  Optional[Integer]                               $timeout                = undef,
   Optional[String]                                $log_path               = undef,
   Optional[String]                                $lock_path              = undef,
   Optional[String]                                $confdir                = undef,
@@ -188,7 +192,7 @@ class pe_event_forwarding (
     group   => $group,
     mode    => '0600',
     require => File[$full_confdir],
-    content => Deferred('inline_epp', [file('pe_event_forwarding/collection_secrets.yaml.epp'), $secrets]),
+    content => Sensitive(Deferred('inline_epp', [file('pe_event_forwarding/collection_secrets.yaml.epp'), $secrets])),
   }
 
   file { "${full_confdir}/collect_api_events.rb":

--- a/templates/collection_settings.yaml.epp
+++ b/templates/collection_settings.yaml.epp
@@ -18,3 +18,6 @@
 <% if $pe_event_forwarding::skip_jobs{ -%>
 "skip_jobs" : <%= $pe_event_forwarding::skip_jobs %>
 <% } -%>
+<% if $pe_event_forwarding::timeout{ -%>
+"timeout" : "<%= $pe_event_forwarding::timeout %>"
+<% } -%>


### PR DESCRIPTION
# Summary

This commit adds an optional parameter `pe_event_forwarding::timeout` to allow users to configure the HTTP timeout used when collecting events.

# Detailed Description

* `manifests/init.pp`
  * Added `timeout` parameter.
* `templates/collection_settings.yaml.epp`
  * Added `timeout` parameter.
* `files/api/activity.rb`
  * Updated class functions to accept timeout. 
* `files/api/orchestrator.rb`
  * Updated class functions to accept timeout.
* `files/collect_api_events.rb`
  * Added `timeout` variable with default of `60` seconds.
* `files/util/http.rb`
  * Removed default timeout.
  * Convert timeout to an integer.
* `files/util/pe_http.rb`
  * Added debug log message to indicate what value was used for the timeout.
* Updated `README.md`
* Updated `REFERENCE.md`
* Updated `CHANGELOG.md`
* **Maintenance**:
  * `manifests/init.pp` - Ensure sensitivate data is redacted from logs. 